### PR TITLE
Add Institutional theme

### DIFF
--- a/CTFd/themes/institutional/README.md
+++ b/CTFd/themes/institutional/README.md
@@ -1,0 +1,13 @@
+# Institutional Theme
+
+This theme applies a clean layout with a blue and green color scheme.
+
+## Features
+* Primary color: #005b96
+* Accent color: #28a745
+* Light sections use #f8f9fa
+* Nunito font with a 16px base
+* Rounded buttons and shadowed cards
+* Mobile menu toggle and fade‑in animations
+
+Enable this theme by setting `ctf_theme` to `institutional` in the CTFd configuration.

--- a/CTFd/themes/institutional/static/css/theme.css
+++ b/CTFd/themes/institutional/static/css/theme.css
@@ -1,0 +1,78 @@
+/* Institutional theme styles */
+:root {
+    --primary-color: #005b96;
+    --accent-color: #28a745;
+    --light-section: #f8f9fa;
+    --text-color: #333333;
+    --text-color-dark: #212529;
+}
+
+body {
+    background-color: #ffffff;
+    color: var(--text-color);
+    font-family: 'Nunito', Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    color: var(--text-color-dark);
+    font-family: 'Nunito', Arial, sans-serif;
+}
+
+/* Buttons */
+.btn-primary {
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
+    border-radius: 0.25rem;
+    transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
+}
+
+.btn-primary:hover {
+    background-color: darken(var(--primary-color), 5%);
+    border-color: darken(var(--primary-color), 5%);
+}
+
+.btn-success {
+    background-color: var(--accent-color);
+    border-color: var(--accent-color);
+    border-radius: 0.25rem;
+    transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
+}
+
+/* Cards */
+.card {
+    border: 1px solid #ddd;
+    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+    border-radius: 0.25rem;
+}
+
+/* Light sections */
+.section-light {
+    background-color: var(--light-section);
+    padding: 1rem;
+}
+
+/* Form validation */
+.form-control:focus {
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25);
+    transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.form-control.is-invalid {
+    border-color: #dc3545;
+    box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
+}
+
+/* Fade in animation */
+.fade-in {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+}
+
+.fade-in.visible {
+    opacity: 1;
+    transform: translateY(0);
+}

--- a/CTFd/themes/institutional/static/js/theme.js
+++ b/CTFd/themes/institutional/static/js/theme.js
@@ -1,0 +1,20 @@
+// Simple fade-in on scroll effect
+function onScroll() {
+    document.querySelectorAll('.fade-in').forEach(function(el) {
+        var rect = el.getBoundingClientRect();
+        if (rect.top < window.innerHeight - 50) {
+            el.classList.add('visible');
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    onScroll();
+    document.addEventListener('scroll', onScroll, { passive: true });
+    var menuToggle = document.querySelector('.navbar-toggler');
+    if (menuToggle) {
+        menuToggle.addEventListener('click', function() {
+            document.querySelector('.navbar-collapse').classList.toggle('show');
+        });
+    }
+});

--- a/CTFd/themes/institutional/templates/base.html
+++ b/CTFd/themes/institutional/templates/base.html
@@ -1,0 +1,12 @@
+{% extends "core/base.html" %}
+
+{% block stylesheets %}
+    {{ super() }}
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('views.themes', path='css/theme.css') }}">
+{% endblock %}
+
+{% block scripts %}
+    {{ super() }}
+    <script defer src="{{ url_for('views.themes', path='js/theme.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add an `institutional` theme with Nunito fonts and institutional color scheme
- include basic JS for fade-in animations and mobile menu toggle

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_6841ad4a2ca4832c8eb2bd75c61dd83c